### PR TITLE
fix(component): Fixing a higher order function bug with `await`

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,9 @@ const gza = (strings, ...keys) => {
     async render (settings, innerHTML) {
       if (!this._constructed) {
         this._constructed = true
-        await Promise.all(parsed.constructors.map(c => c(this)))
+        for (const c of parsed.constructors) {
+          await c(this)
+        }
         /* We have don't want constructors to trigger another render.
            Instead, we can just reset the re-render and settings state.
          */


### PR DESCRIPTION
Changing a `Promise.all()` to a `for (const c of ...) { await c(this)...` to get ideal coroutine
behavior

fix #7